### PR TITLE
add simple bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,10 @@
+{
+  "name": "snuownd",
+  "version": "1.1.0",
+  "authors": [
+    "Scott McClaugherty <gamefreak4321@gmail.com>"
+  ],
+  "description": "Javascript port of Reddit's \"SnuDown\" markdown parser.",
+  "main": "snuownd.js",
+  "keywords": ["snuownd", "snudown", "markdown", "reddit"]
+}


### PR DESCRIPTION
Adds a simple bower.json to the repo for bower to pick up on.

Will make it searchable with some extra keywords and adds the "main" tag for use with things like wiredep
