### PR TITLE
Bring up to date with snudown master

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "snuownd",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "JavaScript port of Reddit's SnuDown Markdown parser.",
   "author": "Scott McClaugherty <scott.h.mcc@gmail.com>",
   "homepage": "http//github.com/gamefreak/snuownd",

--- a/snuownd.js
+++ b/snuownd.js
@@ -346,7 +346,7 @@
 
 
 	// function autolink_delim(uint8_t *data, size_t link_end, size_t offset, size_t size)
-	function autolink_delim(data_, link_end, offset, size) {
+	function autolink_delim(data_, link_end, offset, max_rewind, size) {
 		var data = data_.slice(offset)
 		var cclose, copen = 0;
 		var i;
@@ -468,8 +468,7 @@
 		return 0;
 	}
 
-
-	function sd_autolink__url(rewind_p, link, data_, offset, size, flags) {
+	function sd_autolink__url(rewind_p, link, data_, offset, max_rewind, size, flags) {
 		var data = data_.slice(offset);
 		var link_end, rewind = 0, domain_len;
 
@@ -486,7 +485,7 @@
 		link_end += domain_len;
 		while (link_end < size && !isspace(data_[offset+link_end])) link_end++;
 
-		link_end = autolink_delim(data_, link_end, offset, size);
+		link_end = autolink_delim(data_, link_end, offset, max_rewind, size);
 
 		if (link_end == 0) return 0;
 
@@ -497,17 +496,60 @@
 		return link_end;
 	}
 
-	function sd_autolink__subreddit(rewind_p, link, data_, offset, size) {
+	/*
+	 * Checks that `prefix_char` occurs on a word boundary just before `data`,
+	 * where `data` points to the character to search to the left of, and a word boundary
+	 * is (currently) a whitespace character, punctuation, or the start of the string.
+	 * Returns the length of the prefix.
+	 */
+	function check_reddit_autolink_prefix(data_, offset, max_rewind, size, prefix_char) {
+		var max_lookbehind = offset;
+		var data = new FakeCharPtr(data_, offset);
+
+		/* Make sure this `/` is part of `/?r/` */
+		if (size < 2 || max_rewind < 1 || data.getChar(-1) != prefix_char)
+			return 0;
+
+		/* Not at the start of the buffer, no inlines to the immediate left of the `prefix_char` */
+		if (max_rewind > 1) {
+			var boundary = data.getChar(-2);
+			if (boundary == '/')
+				return 2;
+			/**
+			 * Here's where our lack of unicode-awareness bites us. We don't correctly
+			 * match punctuation / whitespace characters for the boundary, because we
+			 * reject valid cases like "。r/example" (note the fullwidth period.)
+			 *
+			 * A better implementation might try to rewind over bytes with the 8th bit set, try
+			 * to decode them to a valid codepoint, then do a unicode-aware check on the codepoint.
+			 */
+			else if (ispunct(boundary) || isspace(boundary))
+				return 1;
+			else
+				return 0;
+		} else if (max_lookbehind > 2) {
+			/* There's an inline element just left of the `prefix_char`, is it an escaped forward
+			 * slash? bail out so we correctly handle stuff like "\/r/foo". This will also correctly
+			 * allow "\\/r/foo".
+			 */
+			if (data.getChar(-2) == '/' && data.getChar(-3) == '\\')
+				return 0;
+		}
+
+		/* Must be a new-style shortlink with nothing relevant to the left of it. */
+		return 1;
+	}
+
+	function sd_autolink__subreddit(rewind_p, link, data_, offset, max_rewind, size, no_slash) {
 		var data = data_.slice(offset);
-		var link_end;
+		var link_end = 0;
 		var allMinus = false;
 
-		if (size < 3) return 0;
+		var rewind = check_reddit_autolink_prefix(data_, offset, max_rewind, size, 'r');
+		if (!rewind)
+			return 0;
 
-		/* make sure this / is part of /r/ */
-		if (data.indexOf('/r/') != 0) return 0;
-
-		link_end = "/r/".length;
+		link_end = "/".length;
 		if (data.substr(link_end, 4).toLowerCase() == "all-") {
 			allMinus = true;
 		}
@@ -553,23 +595,28 @@
 			}
 		}
 		/* make the link */
-		link.s += data.slice(0, link_end);
-		rewind_p.p = 0;
+		var sliceStart = offset - rewind;
+		link.s += data_.slice(sliceStart, sliceStart + link_end + rewind);
+
+		no_slash.p = (rewind == 1);
+		rewind_p.p = rewind;
 
 		return link_end;
 	}
 
-	function sd_autolink__username(rewind_p, link, data_, offset, size) {
+	function sd_autolink__username(rewind_p, link, data_, offset, max_rewind, size, no_slash) {
 		var data = data_.slice(offset);
-		var link_end;
+		var link_end = 0;
 
-		if (size < 6) return 0;
+		if (size < 3)
+			return;
 
-		/* make sure this / is part of /u/ */
-		if (data.indexOf('/u/') != 0) return 0;
+		var rewind = check_reddit_autolink_prefix(data_, offset, max_rewind, size, 'u');
+		if (!rewind)
+			return 0;
 
 		/* the first letter of a username must... well, be valid, we don't care otherwise */
-		link_end = "/u/".length;
+		link_end = "/".length;
 		if (!isalnum(data[link_end]) && data[link_end] != '_' && data[link_end] != '-')
 			return 0;
 		link_end += 1;
@@ -582,13 +629,16 @@
 			link_end++;
 
 		/* make the link */
-		link.s += data.slice(0, link_end);
-		rewind_p.p = 0;
+		var sliceStart = offset - rewind;
+		link.s += data_.slice(sliceStart, sliceStart + link_end + rewind);
+
+		no_slash.p = (rewind == 1);
+		rewind_p.p = rewind;
 
 		return link_end;
 	}
 
-	function sd_autolink__email(rewind_p, link, data_, offset, size, flags) {
+	function sd_autolink__email(rewind_p, link, data_, offset, max_rewind, size, flags) {
 		var data = data_.slice(offset);
 		var link_end, rewind;
 		var nb = 0, np = 0;
@@ -618,7 +668,7 @@
 		if (link_end < 2 || nb != 1 || np == 0) return 0;
 
 		//TODO
-		link_end = autolink_delim(data_, link_end, offset, size);
+		link_end = autolink_delim(data_, link_end, offset, max_rewind, size);
 
 		if (link_end == 0) return 0;
 
@@ -629,7 +679,7 @@
 		return link_end;
 	}
 
-	function sd_autolink__www(rewind_p, link, data_, offset, size, flags) {
+	function sd_autolink__www(rewind_p, link, data_, offset, max_rewind, size, flags) {
 		var data = data_.slice(offset);
 		var link_end;
 
@@ -646,7 +696,7 @@
 
 		while (link_end < size && !isspace(data[link_end])) link_end++;
 
-		link_end = autolink_delim(data_, link_end, offset, size);
+		link_end = autolink_delim(data_, link_end, offset, max_rewind, size);
 
 		if (link_end == 0) return 0;
 
@@ -1702,7 +1752,7 @@
 
 	/* char_emphasis • single and double emphasis parsing */
 	//Buffer, md, str, int
-	function char_emphasis(out, md, data_, offset) {
+	function char_emphasis(out, md, data_, offset, max_rewind) {
 		var data = data_.slice(offset);
 		var size = data.length;
 		var c = data[0];
@@ -1735,7 +1785,7 @@
 	}
 
 	/* char_codespan - '`' parsing a code span (assuming codespan != 0) */
-	function char_codespan(out, md, data_, offset) {
+	function char_codespan(out, md, data_, offset, max_rewind) {
 		var data = data_.slice(offset);
 		var end, nb = 0, i, f_begin, f_end;
 
@@ -1774,7 +1824,7 @@
 	}
 
 	/* char_linebreak - '\n' preceded by two spaces (assuming linebreak != 0) */
-	function char_linebreak(out, md, data_, offset) {
+	function char_linebreak(out, md, data_, offset, max_rewind) {
 		var data = data_.slice(offset);
 		if (offset < 2 || data_[offset-1] != ' ' || data_[offset-2] != ' ')
 			return 0;
@@ -1788,7 +1838,7 @@
 	}
 
 	/* char_link - '[': parsing a link or an image */
-	function char_link(out, md, data_, offset) {
+	function char_link(out, md, data_, offset, max_rewind) {
 		var data = data_.slice(offset);
 		var is_img = (offset && data_[offset - 1] == '!'), level;
 		var i = 1, txt_e, link_b = 0, link_e = 0, title_b = 0, title_e = 0;
@@ -2018,7 +2068,7 @@
 
 
 	/* char_langle_tag - '<' when tags or autolinks are allowed */
-	function char_langle_tag(out, md, data_, offset) {
+	function char_langle_tag(out, md, data_, offset, max_rewind) {
 		var data = data_.slice(offset);
 		var altype = {p:MKDA_NOT_AUTOLINK};
 		var end = tag_length(data, altype);
@@ -2044,7 +2094,7 @@
 
 
 	/* char_escape - '\\' backslash escape */
-	function char_escape(out, md, data_, offset) {
+	function char_escape(out, md, data_, offset, max_rewind) {
 		var data = data_.slice(offset);
 		var escape_chars = "\\`*_{}[]()#+-.!:|&<>/^~";
 		var work = new Buffer();
@@ -2068,7 +2118,7 @@
 
 	/* char_entity - '&' escaped when it doesn't belong to an entity */
 	//-/* valid entities are assumed to be anything matching &#?[A-Za-z0-9]+; */
-	function char_entity(out, md, data_, offset) {
+	function char_entity(out, md, data_, offset, max_rewind) {
 		var data = data_.slice(offset);
 		var end = 1, content_start, content_end;
 		var numeric = false, hex = false, entity_base, entity_val;
@@ -2129,7 +2179,7 @@
 		return end;
 	}
 
-	function char_autolink_url(out, md, data_, offset) {
+	function char_autolink_url(out, md, data_, offset, max_rewind) {
 		var data = data_.slice(offset);
 		var link = null;
 		var link_len, rewind = {p: null};
@@ -2139,7 +2189,7 @@
 		link = new Buffer();
 		md.spanStack.push(link);
 
-		if ((link_len = sd_autolink__url(rewind, link, data_, offset, data.length, 0)) > 0) {
+		if ((link_len = sd_autolink__url(rewind, link, data_, offset, max_rewind, data.length, 0)) > 0) {
 			if (rewind.p > 0) out.truncate(out.s.length - rewind.p);
 			md.callbacks.autolink(out, link, MKDA_NORMAL, md.context);
 		}
@@ -2149,7 +2199,7 @@
 	}
 
 
-	function char_autolink_email(out, md, data_, offset) {
+	function char_autolink_email(out, md, data_, offset, max_rewind) {
 		var data = data_.slice(offset);
 		var link = null;
 		var link_len, rewind = {p: null};
@@ -2159,7 +2209,7 @@
 		link = new Buffer();
 		md.spanStack.push(link);
 
-		if ((link_len = sd_autolink__email(rewind, link, data_, offset, data.length, 0)) > 0) {
+		if ((link_len = sd_autolink__email(rewind, link, data_, offset, max_rewind, data.length, 0)) > 0) {
 			if (rewind.p > 0) out.truncate(out.s.length - rewind.p);
 			md.callbacks.autolink(out, link, MKDA_EMAIL, md.context);
 		}
@@ -2169,7 +2219,7 @@
 	}
 
 
-	function char_autolink_www(out, md, data_, offset) {
+	function char_autolink_www(out, md, data_, offset, max_rewind) {
 		var data = data_.slice(offset);
 		var link = null, link_url = null, link_text = null;
 		var link_len, rewind = {p: null};
@@ -2179,7 +2229,7 @@
 		link = new Buffer();
 		md.spanStack.push(link);
 
-		if ((link_len = sd_autolink__www(rewind, link, data_, offset, data.length, 0)) > 0) {
+		if ((link_len = sd_autolink__www(rewind, link, data_, offset, max_rewind, data.length, 0)) > 0) {
 			link_url = new Buffer();
 			md.spanStack.push(link_url);
 			link_url.s += 'http://';
@@ -2203,30 +2253,47 @@
 		return link_len;
 	}
 
-	function char_autolink_subreddit_or_username(out, md, data_, offset) {
+	function char_autolink_subreddit_or_username(out, md, data_, offset, max_rewind) {
 		var data = data_.slice(offset);
 		var link = null;
-		var link_len, rewind = {p: null};
+		var link_len = 0;
+		var rewind = {p: null}, no_slash = {p: null};
 
 		if (!md.callbacks.autolink || md.inLinkBody) return 0;
 
 		link = new Buffer();
 		md.spanStack.push(link);
-		if ((link_len = sd_autolink__subreddit(rewind, link, data_, offset, data.length)) > 0) {
-			//don't slice because the rewind pointer will always be 0
+		link_len = sd_autolink__subreddit(rewind, link, data_, offset, max_rewind, data.length, no_slash);
+		if (link_len === 0)
+			link_len = sd_autolink__username(rewind, link, data_, offset, max_rewind, data.length, no_slash);
+
+		/* Found either a user or subreddit link */
+		if (link_len > 0) {
+			var link_url = new Buffer();
+			md.spanStack.push(link_url);
+
+			if (no_slash.p)
+				link_url.s += "/";
+			link_url.s += link.s;
+
 			if (rewind.p > 0) out.truncate(out.s.length - rewind.p);
-			md.callbacks.autolink(out, link, MKDA_NORMAL, md.context);
-		} else if ((link_len = sd_autolink__username(rewind, link, data_, offset, data.length)) > 0) {
-			//don't slice because the rewind pointer will always be 0
-			if (rewind.p > 0) out.truncate(out.s.length - rewind.p);
-			md.callbacks.autolink(out, link, MKDA_NORMAL, md.context);
+
+			if (md.callbacks.normal_text) {
+				var link_text = new Buffer();
+				md.spanStack.push(link_text);
+				md.callbacks.normal_text(link_text, link, md.context);
+				md.callbacks.link(out, link_url, null, link_text, md.context);
+				md.spanStack.pop();
+			} else {
+				md.callbacks.link(out, link_url, null, link, md.context);
+			}
+			md.spanStack.pop();
 		}
 		md.spanStack.pop();
-
 		return link_len;
 	}
 
-	function char_superscript(out, md, data_, offset) {
+	function char_superscript(out, md, data_, offset, max_rewind) {
 		var data = data_.slice(offset);
 		var size = data.length;
 		var sup_start, sup_len;
@@ -2352,6 +2419,30 @@
 		if (size < 0) throw new RangeError("Size argument is negative");
 		this.s = this.s.slice(0, size);
 	}
+
+	/**
+	 * For when you need a view into a string that behaves like a
+	 * C's mutable `char *`.
+	 */
+	function FakeCharPtr(str, offset) {
+		this.s = str;
+		if (offset >= str.length || offset < 0)
+			throw new RangeError("char * offset out of bounds");
+		this.offset = offset;
+	}
+
+	FakeCharPtr.prototype.getChar = function(idx) {
+		var absIdx = this.offset + idx;
+		if (absIdx >= this.s.length || absIdx < 0)
+			throw new RangeError("Character index out of bounds");
+		return this.s.slice(absIdx, absIdx + 1);
+	}
+
+	FakeCharPtr.prototype.toString = function() {
+		return this.s.slice(this.offset);
+	}
+
+	// TODO: Support more string-like functionality for `FakeCharPtr`s
 
 
 	/**
@@ -2886,7 +2977,7 @@
 	// parse_inline - parses inline markdown elements 
 	//Buffer, md, String
 	function parse_inline(out, md, data) {
-		var i = 0, end = 0;
+		var i = 0, end = 0, last_special = 0;
 		var action = 0;
 		var work = new Buffer();
 
@@ -2909,12 +3000,12 @@
 			if (end >= data.length) break;
 			i = end;
 
-			end = markdown_char_ptrs[action](out, md, data, i);
+			end = markdown_char_ptrs[action](out, md, data, i, i - last_special);
 			if (!end) /* no action from the callback */
 				end = i + 1;
 			else {
 				i += end;
-				end = i;
+				last_special = end = i;
 			}
 		}
 	}

--- a/snuownd.js
+++ b/snuownd.js
@@ -474,7 +474,7 @@
 
 		if (size < 4 || data_[offset+1] != '/' || data_[offset+2] != '/') return 0;
 
-		while (rewind < offset && isalpha(data_[offset-rewind - 1])) rewind++;
+		while (rewind < max_rewind && isalpha(data_[offset-rewind - 1])) rewind++;
 
 		if (!sd_autolink_issafe(data_.substr(offset-rewind, size+rewind))) return 0;
 		link_end = "://".length;
@@ -643,7 +643,7 @@
 		var link_end, rewind;
 		var nb = 0, np = 0;
 
-		for (rewind = 0; rewind < offset; ++rewind) {
+		for (rewind = 0; rewind < max_rewind; ++rewind) {
 			var c = data_[offset-rewind - 1];
 
 			if (c == '\0') break;
@@ -683,7 +683,7 @@
 		var data = data_.slice(offset);
 		var link_end;
 
-		if (offset > 0 && !ispunct(data_[offset-1]) && !isspace(data_[offset-1]))
+		if (max_rewind > 0 && !ispunct(data_[offset-1]) && !isspace(data_[offset-1]))
 			return 0;
 
 		// if (size < 4 || memcmp(data, "www.", strlen("www.")) != 0)
@@ -1826,7 +1826,7 @@
 	/* char_linebreak - '\n' preceded by two spaces (assuming linebreak != 0) */
 	function char_linebreak(out, md, data_, offset, max_rewind) {
 		var data = data_.slice(offset);
-		if (offset < 2 || data_[offset-1] != ' ' || data_[offset-2] != ' ')
+		if (max_rewind < 2 || data_[offset-1] != ' ' || data_[offset-2] != ' ')
 			return 0;
 
 		/* removing the last space from ob and rendering */
@@ -1840,7 +1840,7 @@
 	/* char_link - '[': parsing a link or an image */
 	function char_link(out, md, data_, offset, max_rewind) {
 		var data = data_.slice(offset);
-		var is_img = (offset && data_[offset - 1] == '!'), level;
+		var is_img = (max_rewind && data_[offset - 1] == '!'), level;
 		var i = 1, txt_e, link_b = 0, link_e = 0, title_b = 0, title_e = 0;
 		//4 bufs
 		var content = null;

--- a/snuownd.js
+++ b/snuownd.js
@@ -508,7 +508,7 @@
 		if (data.indexOf('/r/') != 0) return 0;
 
 		link_end = "/r/".length;
-		if (data.substr(link_end-1, 4).toLowerCase() == "all-") {
+		if (data.substr(link_end, 4).toLowerCase() == "all-") {
 			allMinus = true;
 		}
 		do {

--- a/snuownd.js
+++ b/snuownd.js
@@ -130,7 +130,7 @@
 		 *	 xrange(65534, 65535)]
 		 */
 		return (entity_val > 8
-		    && (entity_val !== 11 && entity_val > 12)
+		    && (entity_val !== 11 && entity_val !== 12)
 		    && (entity_val < 14 || entity_val > 31)
 		    && (entity_val < 55296 || entity_val > 57343)
 		    && (entity_val !== 65534 && entity_val !== 65535)

--- a/test.js
+++ b/test.js
@@ -244,6 +244,36 @@ cases = {
     'a。r/reddit.com':
         '<p>a。r/reddit.com</p>\n',
 
+    '/R/reddit.com':
+        '<p>/R/reddit.com</p>\n',
+
+    '/r/irc://foo.bar/':
+        '<p><a href="/r/irc">/r/irc</a>://foo.bar/</p>\n',
+
+    '/r/t:irc//foo.bar/':
+        '<p><a href="/r/t:irc//foo">/r/t:irc//foo</a>.bar/</p>\n',
+
+    '/r/all-irc://foo.bar/':
+        '<p><a href="/r/all-irc">/r/all-irc</a>://foo.bar/</p>\n',
+
+    '/r/foo+irc://foo.bar/':
+        '<p><a href="/r/foo+irc">/r/foo+irc</a>://foo.bar/</p>\n',
+
+    '/r/www.example.com':
+        '<p><a href="/r/www">/r/www</a>.example.com</p>\n',
+
+    '.http://reddit.com':
+        '<p>.<a href="http://reddit.com">http://reddit.com</a></p>\n',
+
+    '[r://<http://reddit.com/>](/aa)':
+        '<p><a href="/aa">r://<a href="http://reddit.com/">http://reddit.com/</a></a></p>\n',
+
+    '/u/http://www.reddit.com/user/reddit':
+        '<p><a href="/u/http">/u/http</a>://<a href="http://www.reddit.com/user/reddit">www.reddit.com/user/reddit</a></p>\n',
+
+    'www.http://example.com/':
+        '<p><a href="http://www.http://example.com/">www.http://example.com/</a></p>\n',
+
     '&thetasym;': '<p>&thetasym;</p>\n',
     '&foobar;': '<p>&amp;foobar;</p>\n',
     '&nbsp': '<p>&amp;nbsp</p>\n',

--- a/test.js
+++ b/test.js
@@ -165,6 +165,85 @@ cases = {
     '/r/t:heatdeathoftheuniverse':
         '<p><a href="/r/t:heatdeathoftheuniverse">/r/t:heatdeathoftheuniverse</a></p>\n',
 
+    'a /u/reddit':
+        '<p>a <a href="/u/reddit">/u/reddit</a></p>\n',
+
+    'u/reddit':
+        '<p><a href="/u/reddit">u/reddit</a></p>\n',
+
+    'a u/reddit':
+        '<p>a <a href="/u/reddit">u/reddit</a></p>\n',
+
+    'a u/reddit/foobaz':
+        '<p>a <a href="/u/reddit/foobaz">u/reddit/foobaz</a></p>\n',
+
+    'foo:u/reddit':
+        '<p>foo:<a href="/u/reddit">u/reddit</a></p>\n',
+
+    'fuu/reddit':
+        '<p>fuu/reddit</p>\n',
+
+    // Don't treat unicode punctuation as a word boundary for now
+    'a。u/reddit':
+        '<p>a。u/reddit</p>\n',
+
+    '\\/u/me':
+        '<p>/u/me</p>\n',
+
+    '\\\\/u/me':
+        '<p>\\<a href="/u/me">/u/me</a></p>\n',
+
+    '\\u/me':
+        '<p>\\<a href="/u/me">u/me</a></p>\n',
+
+    '\\\\u/me':
+        '<p>\\<a href="/u/me">u/me</a></p>\n',
+
+    'u\\/me':
+        '<p>u/me</p>\n',
+
+    '*u/me*':
+        '<p><em><a href="/u/me">u/me</a></em></p>\n',
+
+    'foo^u/me':
+        '<p>foo<sup><a href="/u/me">u/me</a></sup></p>\n',
+
+    '*foo*u/me':
+        '<p><em>foo</em><a href="/u/me">u/me</a></p>\n',
+
+    'u/me':
+        '<p><a href="/u/me">u/me</a></p>\n',
+
+    '/u/me':
+        '<p><a href="/u/me">/u/me</a></p>\n',
+
+    'u/m':
+        '<p>u/m</p>\n',
+
+    '/u/m':
+        '<p>/u/m</p>\n',
+
+    '/f/oobar':
+        '<p>/f/oobar</p>\n',
+
+    'f/oobar':
+        '<p>f/oobar</p>\n',
+
+    'a /r/reddit.com':
+        '<p>a <a href="/r/reddit.com">/r/reddit.com</a></p>\n',
+
+    'a r/reddit.com':
+        '<p>a <a href="/r/reddit.com">r/reddit.com</a></p>\n',
+
+    'foo:r/reddit.com':
+        '<p>foo:<a href="/r/reddit.com">r/reddit.com</a></p>\n',
+
+    'foobar/reddit.com':
+        '<p>foobar/reddit.com</p>\n',
+
+    'a。r/reddit.com':
+        '<p>a。r/reddit.com</p>\n',
+
     '&thetasym;': '<p>&thetasym;</p>\n',
     '&foobar;': '<p>&amp;foobar;</p>\n',
     '&nbsp': '<p>&amp;nbsp</p>\n',

--- a/test.js
+++ b/test.js
@@ -210,7 +210,7 @@ var ILLEGAL_NUMERIC_ENT_RANGES = [
 
 var invalid_ent_test_key = '';
 var invalid_ent_test_val = '';
-for (var r of ILLEGAL_NUMERIC_ENT_RANGES.values()) {
+for (var r of ILLEGAL_NUMERIC_ENT_RANGES) {
     for (var i of r) {
         invalid_ent_test_key += '&#' + i + ';';
         invalid_ent_test_val += '&amp;#' + i + ';';

--- a/test.js
+++ b/test.js
@@ -156,6 +156,12 @@ cases = {
     '/r/very+clever+multireddit+reddit.com+t:fork+yay':
         '<p><a href="/r/very+clever+multireddit+reddit.com+t:fork+yay">/r/very+clever+multireddit+reddit.com+t:fork+yay</a></p>\n',
 
+    '/r/all-minus-something':
+        '<p><a href="/r/all-minus-something">/r/all-minus-something</a></p>\n',
+
+    '/r/notall-minus':
+        '<p><a href="/r/notall">/r/notall</a>-minus</p>\n',
+
     '/r/t:heatdeathoftheuniverse':
         '<p><a href="/r/t:heatdeathoftheuniverse">/r/t:heatdeathoftheuniverse</a></p>\n',
 


### PR DESCRIPTION
A few changes here:
- Fixed an incorrect range check for numeric entities
- `/r/all-foo-bar` links now work
- Autolinks like `/r/http://example.com/` no longer output malformed HTML
- Added support for the upcoming `u/username` and `r/subreddit`-style autolinks

One thing I wanted to point out though, in SnuOwnd `data` almost always points to the beginning of the buffer, whereas in Snudown it always points to `data + offset`. JS doesn't seem to have anything like C's mutable `char` pointers, so I just mimicked it by making a `FakeCharPtr` wrapper that takes a JS string and an offset. Moving to that rather than using the `var data = data_.slice(offset)` hack should make it easier to port Snudown changes to SnuOwnd (especially ones that rely on rewinds.)
